### PR TITLE
Update FFTNode.cpp to return correct dimentions

### DIFF
--- a/libraries/nodes/src/FFTNode.cpp
+++ b/libraries/nodes/src/FFTNode.cpp
@@ -301,14 +301,14 @@ namespace nodes
     {
         double nearestPowerOf2Size = std::pow(2, std::ceil(std::log2(input.Size())));
         _fftSize = static_cast<size_t>(nearestPowerOf2Size);
-        _output.SetSize(_fftSize / 2);
+        _output.SetSize(_fftSize / 2 + 1);
     }
 
     template <typename ValueType>
     FFTNode<ValueType>::FFTNode(const model::OutputPort<ValueType>& input, size_t fftSize) :
         CompilableNode({ &_input }, { &_output }),
         _input(this, input, defaultInputPortName),
-        _output(this, defaultOutputPortName, fftSize / 2),
+        _output(this, defaultOutputPortName, fftSize / 2 + 1),
         _fftSize(fftSize)
     {
         if (fftSize == 0)
@@ -747,7 +747,7 @@ namespace nodes
         {
             _fftSize = _input.Size();
         }
-        _output.SetSize(_fftSize / 2);
+        _output.SetSize(_fftSize / 2 + 1);
     }
 
     // Explicit instantiations


### PR DESCRIPTION
If we do an FFT providing parameter NFFT as 256
The output dimensions are (NFFT/2 + 1) = 129
You can crosscheck it using numpy by running the below code
import numpy as np
x = np.array(range(160))
NFFT = 256
fft = np.fft.rfft(x, NFFT)
mag = np.absolute(fft)
print(mag.shape)
# output is (129,)